### PR TITLE
Fix remote code execution vulnerability

### DIFF
--- a/chapter_9/oauth1-python-3legged/index.py
+++ b/chapter_9/oauth1-python-3legged/index.py
@@ -29,7 +29,7 @@ def main():
     oauth_token_secret = token_params['oauth_token_secret'][0]
 
     #generate cookie with request token key and secret to pass through authorization process
-    cookie = Cookie.Cookie()
+    cookie = Cookie.SimpleCookie()
     cookie_token = 'token=%s&token_secret=%s' % (oauth_token, oauth_token_secret)
     cookie['request_token'] = cookie_token
     cookie['timestamp'] = time.time()


### PR DESCRIPTION
SmartCookie as well as SerialCookie are vulnerable to code injection in python2.
Cookie.Cookie maps to Cookie.SmartCookie.
For example, the following cookie header would shutdown your server:
Cookie: foo="cposix\012_exit\012p1\012(I1\012tp2\012Rp3\012."
